### PR TITLE
feat(experimental): authorship

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -34,9 +34,10 @@ window.parseHtml = () => {
   const lang = document.getElementById("lang").checked;
   const textContent = document.getElementById("textContent").checked;
   const metaformats = document.getElementById("metaformats").checked;
+  const authorship = document.getElementById("authorship").checked;
 
   return parse(html, {
     baseUrl,
-    experimental: { lang, textContent, metaformats },
+    experimental: { lang, textContent, metaformats, authorship },
   });
 };

--- a/demo/index.tpl.html
+++ b/demo/index.tpl.html
@@ -83,6 +83,16 @@
             />
             <span>Metaformats parsing</span>
           </label>
+          <label>
+            <input
+              type="checkbox"
+              name="authorship"
+              id="authorship"
+              value="true"
+              checked
+            />
+            <span>Authorship discovery</span>
+          </label>
         </p>
 
         <div class="submit">

--- a/src/helpers/authorship.ts
+++ b/src/helpers/authorship.ts
@@ -1,0 +1,108 @@
+import {
+  Author,
+  Image,
+  MicroformatProperty,
+  MicroformatRoot,
+  Rels,
+} from "../types";
+
+function getPlainText(values: MicroformatProperty[]): string | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const value = values[0] as Author;
+  let plainText: string | null;
+  if (value.value !== undefined && typeof value.value === "string") {
+    plainText = value.value;
+  } else if (typeof value === "string") {
+    plainText = value;
+  } else {
+    plainText = null;
+  }
+
+  return plainText && plainText.trim();
+}
+
+const parseAuthor = (hCard: MicroformatRoot) => {
+  // TODO: Figure out how to stop TypeScript complaining about missing `value`
+  const result: Author = {};
+
+  if (hCard.properties !== undefined) {
+    // Use first (or only) name
+    const names = hCard.properties.name as string[];
+    if (names?.length > 0) {
+      result.name = names[0];
+    }
+
+    // Use first (or only) photo
+    const photos = hCard.properties.photo as Image[];
+    if (photos?.length > 0) {
+      const photo = getPlainText(photos);
+      if (photo) {
+        result.photo = photo;
+      }
+    }
+
+    // Use first (or only) URL
+    const urls = hCard.properties.url as string[];
+    if (urls?.length > 0) {
+      result.url = urls[0];
+    }
+  } else if (hCard) {
+    if (URL.canParse(String(hCard))) {
+      result.url = String(hCard);
+    } else {
+      result.name = String(hCard);
+    }
+  }
+
+  return result as Author;
+};
+
+const findEntryAuthor = (hEntry: MicroformatRoot) => {
+  const values = hEntry.properties.author || [];
+
+  if (Object.keys(values).length === 0) {
+    return;
+  }
+
+  return parseAuthor(values[0] as MicroformatRoot);
+};
+
+const findFeedAuthor = () => false;
+
+export const findAuthor = async (item: MicroformatRoot, rels: Rels) => {
+  // 1. If no `h-entry` then there’s no post to find authorship for.
+  const itemIsEntry = item.type && item.type[0] === "h-entry";
+  if (!itemIsEntry) {
+    return false;
+  }
+
+  // 2. Parse the `h-entry`
+  const entryAuthor = findEntryAuthor(item);
+  const feedAuthor = findFeedAuthor(); // TODO
+
+  // 3 & 4. Return author in `h-entry`, else find author in parent `h-feed`
+  const author = entryAuthor ? entryAuthor : feedAuthor;
+
+  // 5. Return `author` if `h-card`
+  const authorIsCard = author && author.type[0] === "h-card";
+  if (authorIsCard) {
+    return author;
+  }
+
+  // 6. Use `h-card` fetched from rel=author
+  const authorPage = author.properties?.url || rels.author;
+  if (authorPage) {
+    // Fetch `authorPage` and parse result using `parseMicroformat`
+    // This is an async function, which would bubble up to the parent function
+  }
+
+  // 7. From the parsed `authorPage`, return the first `h-card` that either:
+  //    * Has a value for `u-url` (or `u-uid`) that matches the `authorPage` URL
+  //    * Has a value for `u-url` that matches a `rel=me` on the `authorPage`
+
+  // 8. Else, no deterministic author can be found
+  return author;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export interface Options {
     lang?: boolean;
     textContent?: boolean;
     metaformats?: boolean;
+    authorship?: boolean;
   };
 }
 

--- a/src/microformats/parse.ts
+++ b/src/microformats/parse.ts
@@ -86,7 +86,7 @@ export const parseMicroformat = (
   }
 
   /**
-   * There is some ambigutity on how this should be handled.
+   * There is some ambiguity on how this should be handled.
    * At the moment, we're following other parsers and keeping `value` a string
    * and adding `html` as an undocumented property.
    */

--- a/src/microformats/parse.ts
+++ b/src/microformats/parse.ts
@@ -5,6 +5,7 @@ import {
   Element,
 } from "../types";
 import { microformatProperties } from "./properties";
+import { findAuthor } from "../helpers/authorship";
 import { textContent } from "../helpers/textContent";
 import { getAttributeValue, getClassNames } from "../helpers/attributes";
 import { findChildren } from "../helpers/findChildren";
@@ -64,6 +65,15 @@ export const parseMicroformat = (
 
   if (isEnabled(options, "lang") && lang) {
     item.lang = lang;
+  }
+
+  if (isEnabled(options, "authorship")) {
+    const author = findAuthor(item, options.rels);
+
+    if (author) {
+      console.log("author", author);
+      // item.properties.author = author;
+    }
   }
 
   if (children.length) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -23,6 +23,7 @@ export const parser = (
     baseUrl,
     idRefs,
     inherited: { roots: [], lang },
+    rels,
   };
   let items = findChildren(doc, isMicroformatRoot).map((mf) =>
     parseMicroformat(mf, parsingOptions),

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface ParserOptions {
     lang?: boolean;
     textContent?: boolean;
     metaformats?: boolean;
+    authorship?: boolean;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface ParsingOptions extends ParserOptions {
     roots: BackcompatRoot[];
     lang?: string;
   };
+  rels: Rels;
 }
 
 export interface ParsedDocument {
@@ -46,6 +47,13 @@ export interface MicroformatRoot {
   value?: MicroformatProperty;
 }
 
+export interface Author {
+  name?: string;
+  value: string;
+  photo?: string;
+  url?: string;
+}
+
 export interface Image {
   alt: string;
   value?: string;
@@ -57,7 +65,12 @@ export interface Html {
   lang?: string;
 }
 
-export type MicroformatProperty = MicroformatRoot | Image | Html | string;
+export type MicroformatProperty =
+  | MicroformatRoot
+  | Author
+  | Image
+  | Html
+  | string;
 
 export type Rels = Record<string, string[]>;
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -81,7 +81,7 @@ export const validator = (
   if ("experimental" in options) {
     const experimental = assertIsObject(
       options.experimental,
-      ["lang", "textContent", "metaformats"],
+      ["lang", "textContent", "metaformats", "authorship"],
       "experimental",
     );
 
@@ -95,6 +95,10 @@ export const validator = (
 
     if ("metaformats" in experimental) {
       assertIsBoolean(experimental.metaformats, "experimental.metaformats");
+    }
+
+    if ("authorship" in experimental) {
+      assertIsBoolean(experimental.authorship, "experimental.authorship");
     }
   }
 };

--- a/test/scenarios.spec.ts
+++ b/test/scenarios.spec.ts
@@ -67,7 +67,12 @@ describe("mf2() // experimental scenarios", () => {
     it(`should correctly parse ${name}`, () => {
       const result = mf2(input, {
         ...options,
-        experimental: { lang: true, textContent: true, metaformats: true },
+        experimental: {
+          lang: true,
+          textContent: true,
+          metaformats: true,
+          authorship: true,
+        },
       });
       expect(result).to.deep.equal(expected);
     });

--- a/test/suites/experimental/authorship-h-card-with-rel-author-to-rel-me.html
+++ b/test/suites/experimental/authorship-h-card-with-rel-author-to-rel-me.html
@@ -1,0 +1,16 @@
+<!-- This next entry is by Virginia Woolf. Her URL is https://virginia.example, and her photo is at https://virginia.example/photo.jpg. -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Entry with rel=author (links to h-card with rel=me)</title>
+  </head>
+  <body class="h-entry">
+    <div class="e-content">
+      <p>A woman must have money and a room of her own if she is to write fiction.</p>
+    </div>
+    <footer>
+      <a href="https://virginia.woolf" rel="author">About Virginia Woolf</a>
+    </footer>
+  </body>
+</html>

--- a/test/suites/experimental/authorship-h-card-with-rel-author-to-rel-me.json
+++ b/test/suites/experimental/authorship-h-card-with-rel-author-to-rel-me.json
@@ -1,0 +1,38 @@
+{
+  "items": [
+    {
+      "type": ["h-entry"],
+      "lang": "en",
+      "properties": {
+        "author": [
+          {
+            "type": ["h-card"],
+            "lang": "en",
+            "properties": {
+              "name": ["Virginia Woolf"],
+              "photo": ["https://virginia.example/photo.jpg"],
+              "url": ["https://virginia.example"]
+            },
+            "value": "Virginia Woolf"
+          }
+        ],
+        "content": [
+          {
+            "value": "A woman must have money and a room of her own if she is to write fiction.",
+            "lang": "en",
+            "html": "<p>A woman must have money and a room of her own if she is to write fiction.</p>"
+          }
+        ]
+      }
+    }
+  ],
+  "rel-urls": {
+    "https://virginia.woolf": {
+      "rels": ["author"],
+      "text": "About Virginia Woolf"
+    }
+  },
+  "rels": {
+    "author": ["https://virginia.woolf"]
+  }
+}

--- a/test/suites/experimental/authorship-h-card-with-rel-author-to-u-url.html
+++ b/test/suites/experimental/authorship-h-card-with-rel-author-to-u-url.html
@@ -1,0 +1,16 @@
+<!-- This is a haiku by Basho. His URL is https://basho.example, and his photo is at https://basho.example/photo.jpg. -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Entry with rel=author (links to h-card with u-url and u-uid)</title>
+  </head>
+  <body class="h-entry">
+    <div class="e-content" lang="jp">
+      <p>古池や<br />蛙飛び込む<br />水の音</p>
+    </div>
+    <footer>
+      <a href="https://basho.example" rel="author">About Basho</a>
+    </footer>
+  </body>
+</html>

--- a/test/suites/experimental/authorship-h-card-with-rel-author-to-u-url.json
+++ b/test/suites/experimental/authorship-h-card-with-rel-author-to-u-url.json
@@ -1,0 +1,38 @@
+{
+  "items": [
+    {
+      "type": ["h-entry"],
+      "lang": "en",
+      "properties": {
+        "author": [
+          {
+            "type": ["h-card"],
+            "lang": "en",
+            "properties": {
+              "name": ["Basho"],
+              "photo": ["https://basho.example/photo.jpg"],
+              "url": ["https://basho.example"]
+            },
+            "value": "Basho"
+          }
+        ],
+        "content": [
+          {
+            "value": "古池や\n蛙飛び込む\n水の音",
+            "lang": "jp",
+            "html": "<p>古池や<br>蛙飛び込む<br>水の音</p>"
+          }
+        ]
+      }
+    }
+  ],
+  "rel-urls": {
+    "https://basho.example": {
+      "rels": ["author"],
+      "text": "About Basho"
+    }
+  },
+  "rels": {
+    "author": ["https://basho.example"]
+  }
+}

--- a/test/suites/experimental/authorship-h-card-with-rel-author.html
+++ b/test/suites/experimental/authorship-h-card-with-rel-author.html
@@ -1,0 +1,21 @@
+<!-- This is an entry by Patañjali. His URL is https://patanjali.example, and he uses no photo. -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Entry with separate h-card and rel=author</title>
+  </head>
+  <body class="h-entry">
+    <div class="e-content">
+      <p>For one who sees the distinction, there is no further confusing of the mind with the self.</p>
+    </div>
+    <p class="p-author h-card">
+      <a href="https://patanjali.example" class="u-url">
+        <span class="p-name">Patañjali</span>
+      </a>
+    </p>
+    <footer>
+      <a href="https://patanjali.example" rel="author">About Patañjali</a>
+    </footer>
+  </body>
+</html>

--- a/test/suites/experimental/authorship-h-card-with-rel-author.json
+++ b/test/suites/experimental/authorship-h-card-with-rel-author.json
@@ -1,0 +1,37 @@
+{
+  "items": [
+    {
+      "type": ["h-entry"],
+      "lang": "en",
+      "properties": {
+        "author": [
+          {
+            "type": ["h-card"],
+            "lang": "en",
+            "properties": {
+              "name": ["Patañjali"],
+              "url": ["https://patanjali.example"]
+            },
+            "value": "Patañjali"
+          }
+        ],
+        "content": [
+          {
+            "value": "For one who sees the distinction, there is no further confusing of the mind with the self.",
+            "lang": "en",
+            "html": "<p>For one who sees the distinction, there is no further confusing of the mind with the self.</p>"
+          }
+        ]
+      }
+    }
+  ],
+  "rel-urls": {
+    "https://patanjali.example": {
+      "rels": ["author"],
+      "text": "About Patañjali"
+    }
+  },
+  "rels": {
+    "author": ["https://patanjali.example"]
+  }
+}

--- a/test/suites/experimental/authorship-h-card.html
+++ b/test/suites/experimental/authorship-h-card.html
@@ -1,0 +1,19 @@
+<!-- The name of the author of this entry is Homer. His URL is https://homer.example, he uses https://homer.example/photo.jpg as his photo. -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Entry with h-card</title>
+  </head>
+  <body class="h-entry">
+    <div class="e-content">
+      <p>Even in the house of Hades there is left something, a soul and an image, but there is no real heart of life in it.</p>
+    </div>
+    <footer class="p-author h-card">
+      <a href="https://homer.example" class="u-url">
+        <img src="https://homer.example/photo.jpg" class="u-photo" width="64" />
+        <div class="p-name">Homer</div>
+      </a>
+    </footer>
+  </body>
+</html>

--- a/test/suites/experimental/authorship-h-card.json
+++ b/test/suites/experimental/authorship-h-card.json
@@ -1,0 +1,31 @@
+{
+  "items": [
+    {
+      "type": ["h-entry"],
+      "lang": "en",
+      "properties": {
+        "author": [
+          {
+            "type": ["h-card"],
+            "lang": "en",
+            "properties": {
+              "name": ["Homer"],
+              "photo": ["https://homer.example/photo.jpg"],
+              "url": ["https://homer.example"]
+            },
+            "value": "Homer"
+          }
+        ],
+        "content": [
+          {
+            "value": "Even in the house of Hades there is left something, a soul and an image, but there is no real heart of life in it.",
+            "lang": "en",
+            "html": "<p>Even in the house of Hades there is left something, a soul and an image, but there is no real heart of life in it.</p>"
+          }
+        ]
+      }
+    }
+  ],
+  "rel-urls": {},
+  "rels": {}
+}

--- a/test/suites/experimental/authorship-h-feed.html
+++ b/test/suites/experimental/authorship-h-feed.html
@@ -1,0 +1,30 @@
+<!-- The name of the author of this entry is Aristotle. His URL is https://aristotle.example, he uses https://aristotle.example/photo.jpg as his photo. -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Feed with h-card</title>
+  </head>
+  <body class="h-feed">
+    <article class="h-entry">
+      <div class="e-content">
+        <p>Quality is not an act, it is a habit.</p>
+      </div>
+    </article>
+    <article class="h-entry">
+      <div class="e-content">
+        <p>Whosoever is delighted in solitude is either a wild beast or a god.</p>
+      </div>
+    </article>
+    <footer class="p-author h-card">
+      <a href="https://aristotle.example" class="u-url">
+        <img
+          src="https://aristotle.example/photo.jpg"
+          class="u-photo"
+          width="64"
+        />
+        <div class="p-name">Aristotle</div>
+      </a>
+    </footer>
+  </body>
+</html>

--- a/test/suites/experimental/authorship-h-feed.json
+++ b/test/suites/experimental/authorship-h-feed.json
@@ -1,0 +1,76 @@
+{
+  "items": [
+    {
+      "type": ["h-feed"],
+      "lang": "en",
+      "properties": {
+        "author": [
+          {
+            "type": ["h-card"],
+            "lang": "en",
+            "properties": {
+              "name": ["Aristotle"],
+              "photo": ["https://aristotle.example/photo.jpg"],
+              "url": ["https://aristotle.example"]
+            },
+            "value": "Aristotle"
+          }
+        ]
+      },
+      "children": [
+        {
+          "type": ["h-entry"],
+          "lang": "en",
+          "properties": {
+            "author": [
+              {
+                "type": ["h-card"],
+                "lang": "en",
+                "properties": {
+                  "name": ["Aristotle"],
+                  "photo": ["https://aristotle.example/photo.jpg"],
+                  "url": ["https://aristotle.example"]
+                },
+                "value": "Aristotle"
+              }
+            ],
+            "content": [
+              {
+                "html": "<p>Quality is not an act, it is a habit.</p>",
+                "lang": "en",
+                "value": "Quality is not an act, it is a habit."
+              }
+            ]
+          }
+        },
+        {
+          "type": ["h-entry"],
+          "lang": "en",
+          "properties": {
+            "author": [
+              {
+                "type": ["h-card"],
+                "lang": "en",
+                "properties": {
+                  "name": ["Aristotle"],
+                  "photo": ["https://aristotle.example/photo.jpg"],
+                  "url": ["https://aristotle.example"]
+                },
+                "value": "Aristotle"
+              }
+            ],
+            "content": [
+              {
+                "html": "<p>Whosoever is delighted in solitude is either a wild beast or a god.</p>",
+                "lang": "en",
+                "value": "Whosoever is delighted in solitude is either a wild beast or a god."
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "rel-urls": {},
+  "rels": {}
+}

--- a/test/suites/experimental/authorship-p-author.html
+++ b/test/suites/experimental/authorship-p-author.html
@@ -1,0 +1,16 @@
+<!-- The name of the author of this entry is William Shakespeare. There is no extra information available about him on this page, just his name is the correct answer. -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Entry with p-author</title>
+  </head>
+  <body class="h-entry">
+    <div class="e-content">
+      <p>To be, or not to be: that is the question.</p>
+    </div>
+    <footer>
+      <p class="p-author">William Shakespeare</p>
+    </footer>
+  </body>
+</html>

--- a/test/suites/experimental/authorship-p-author.json
+++ b/test/suites/experimental/authorship-p-author.json
@@ -1,0 +1,20 @@
+{
+  "items": [
+    {
+      "type": ["h-entry"],
+      "lang": "en",
+      "properties": {
+        "author": ["William Shakespeare"],
+        "content": [
+          {
+            "value": "To be, or not to be: that is the question.",
+            "lang": "en",
+            "html": "<p>To be, or not to be: that is the question.</p>"
+          }
+        ]
+      }
+    }
+  ],
+  "rel-urls": {},
+  "rels": {}
+}


### PR DESCRIPTION
**Checklist**

- [x] Added validation to any changes in the parser API.
- [x] Added tests covering the parsing behaviour changes.

**Changes to parsing behaviour**

The [Authorship specification](https://indieweb.org/authorship-spec) is an algorithm for discovering and determining the author of a post. This algorithm is especially useful when implementing Webmention and wanting to infer the authorship of individual posts.

This PR is the start of a discussion about adding this algorithm, either to this project, or somewhere else in the Microformats + Node/JavaScript ecosystem. 

Authorship discovery is currently an open feature request on `mf2tojf2` (see https://github.com/getindiekit/mf2tojf2/issues/22). It would be useful when looking to develop downstream libraries such as [webmention-handler](https://github.com/vandie/webmention-handler) (a project which currently implements [it’s own authorship normalisation](https://github.com/vandie/webmention-handler/blob/main/src/functions/normalize-authors.function.ts)).

There are a few options where authorship discovery and parsing could live:

* Within this package, enabled via an experimental option (this PR currently assumes this option),
* Within this package, provided as a separate and discrete function,
* Within another package ([mf2utiljs](https://github.com/drivet/mf2utiljs) covers this use case, but so far there has been [no response to a request for community involvement](https://github.com/drivet/mf2utiljs/issues/1)),
* Within `mf2tojf2` and other downstream JF2 packages,
* Within `webmention-handler` and other downstream packages that need authorship discovery.

**Example input covered by new behaviour**

Tests have been added with example HTML, largely adapted from the validation examples provided on [authorship.rocks](https://authorship.rocks).

**Example output from new behaviour**

Tests have been added with expected mf2 output. Currently these tests fail, but expectedly as the required discovery and parsing is not performed, even with the experimental `authorship` flag enabled.

**Other changes**

Besides tests, and adding an `authorship` option to the experimental flags, I’ve added the `src/helpers/authorship.ts` helper, whose `findAuthor` function is exported and used in `src/microformats/parse.ts`, where I think it might be called. Again, this is assuming this functionality is added as an experimental option.

I’ve added comments that reflect my best understanding of the algorithm, and where code might  live to implement it. 

One reason why such parsing might want to be provided as a discrete function, is that later stages of the discovery algorithm require fetching remote content and parsing that to find a representative `h-card`. That would require making the entire function asynchronous.

**Anything else**

‘I don't know TypeScript or my tests won't pass’ is a pretty good summary of my weekend.

I’ll try to restrain from adding a long and perhaps unhelpful rant about TypeScript, expect to say that I’ve found it immensely difficult and frustrating trying to put together a useful enough PR, and have instead spent most of my time trying to understand various TypeScript errors and behaviours.

Perhaps a discussion for a separate PR, but I’d love to see this project move to model in which JSDoc type annotations are used (and exported as type definitions). Not only would this make it easier for people without TypeScript knowledge to contribute, it would remove the need for a build step and make the codebase more future proof and portable.`</rant>`