### PR TITLE
fix: don't parse implicit properties with nested property microformats

### DIFF
--- a/src/microformats/parse.ts
+++ b/src/microformats/parse.ts
@@ -10,6 +10,7 @@ import { getAttributeValue, getClassNames } from "../helpers/attributes";
 import { findChildren } from "../helpers/findChildren";
 import {
   isMicroformatChild,
+  isMicroformatRoot,
   isMicroformatV2Root,
 } from "../helpers/nodeMatchers";
 import {
@@ -53,7 +54,7 @@ export const parseMicroformat = (
     type: getMicroformatType(node).sort(),
     properties: microformatProperties(node, {
       ...options,
-      implyProperties: !children.length,
+      implyProperties: !findChildren(node, isMicroformatRoot).length,
       inherited,
     }),
   };

--- a/test/suites/local/microformats-v2/urls.html
+++ b/test/suites/local/microformats-v2/urls.html
@@ -45,3 +45,10 @@
   <img class="u-photo" src="    http://example.com/photo.jpg    " alt="Photo" />
   An image to be trimmed
 </div>
+
+<div class="h-entry">
+  <a href="http://example.com/"></a>
+  <div class="p-author h-card">
+    <span class="p-name">microformats</span>
+  </div>
+</div>

--- a/test/suites/local/microformats-v2/urls.json
+++ b/test/suites/local/microformats-v2/urls.json
@@ -92,6 +92,20 @@
         ]
       },
       "type": ["h-entry"]
+    },
+    {
+      "properties": {
+        "author": [
+          {
+            "properties": {
+              "name": ["microformats"]
+            },
+            "type": ["h-card"],
+            "value": "microformats"
+          }
+        ]
+      },
+      "type": ["h-entry"]
     }
   ],
   "rels": {},


### PR DESCRIPTION
**Checklist**

- [x] Added tests covering the parsing behaviour changes.

**Changes to parsing behaviour**

Previously, this was checking the same array returned by `findChildren()`. However, `findChildren()` excludes children that are the values of properties themselves. Per spec, if there are *any* nested microformats implicit properties should not be parsed.

This now matches the behavior of https://php.microformats.io/.

**Example input covered by new behaviour**

```html
<div class="h-entry">
  <a href="http://example.com/"></a>
  <div class="p-author h-card">
    <span class="p-name">microformats</span>
  </div>
</div>
```

**Example output from new behaviour**

<!-- Delete if not relevant -->

```json
{
  "properties": {
    "author": [
      {
        "properties": {
          "name": ["microformats"]
        },
        "type": ["h-card"],
        "value": "microformats"
      }
    ]
  },
  "type": ["h-entry"]
}
```