### PR TITLE
fix: Handle empty alt for images in implied p-name

### DIFF
--- a/src/helpers/attributes.ts
+++ b/src/helpers/attributes.ts
@@ -8,7 +8,10 @@ export const getAttribute = (
 export const getAttributeValue = (
   node: Element,
   name: string,
-): string | undefined => getAttribute(node, name)?.value;
+): string | undefined => {
+  const attr = getAttribute(node, name)?.value;
+  return attr?.length ? attr : undefined;
+};
 
 export const getClassNames = (
   node: Element,

--- a/src/microformats/property.ts
+++ b/src/microformats/property.ts
@@ -16,7 +16,7 @@ import {
 import { isMicroformatRoot } from "../helpers/nodeMatchers";
 import { parseMicroformat } from "./parse";
 import { valueClassPattern } from "../helpers/valueClassPattern";
-import { textContent } from "../helpers/textContent";
+import { textContent, impliedTextContent } from "../helpers/textContent";
 import { parseImage } from "../helpers/images";
 import { isLocalLink, applyBaseUrl } from "../helpers/url";
 import { convertV1PropertyClassNames } from "../backcompat";
@@ -36,7 +36,7 @@ export const parseP = (node: Element, options: ParsingOptions): string =>
   getAttributeIfTag(node, ["data"], "value") ??
   getAttributeIfTag(node, ["img", "area"], "alt") ??
   getAttributeIfTag(node, ["meta"], "content") ??
-  textContent(node, options);
+  impliedTextContent(node, options);
 
 export const parseU = (
   node: Element,

--- a/test/suites/local/microformats-v2/implied-name.html
+++ b/test/suites/local/microformats-v2/implied-name.html
@@ -1,0 +1,4 @@
+<a class="p-author h-card u-url" href="/">
+  Author
+  <img class="u-photo" src="/photo.jpg" alt="" />
+</a>

--- a/test/suites/local/microformats-v2/implied-name.json
+++ b/test/suites/local/microformats-v2/implied-name.json
@@ -1,0 +1,13 @@
+{
+  "rels": {},
+  "rel-urls": {},
+  "items": [
+    {
+      "type": ["h-card"],
+      "properties": {
+        "photo": ["http://example.com/photo.jpg"],
+        "name": ["Author"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #400 

**Checklist**

- [x] Added validaton to any changes in the parser API.
- [x] Added tests covering the parsing behaviour changes.
- [x] Linked to any relevant issues this will close.
- [x] Tested the output using the [demo](../CONTRIBUTING.md#testing-your-changes).

Empty alt text (`<img alt="" .../>`) is used for implied name properties but the [spec](https://microformats.org/wiki/index.php?title=microformats2-parsing#parsing_for_implied_properties) specifically mentions not using an empty value.

Also changed the behavior to use `impliedTextContent` instead of `textContent` when parsing `p-*` otherwise it adds the images `src` when parsing.

**Example input covered by new behaviour**

```html
<a class="p-author h-card u-url" href="/">
  Author
  <img class="u-photo" src="/photo.jpg" alt="" />
</a>
```

**Example output from new behaviour**

```json
{
  "items": [
    {
      "type": ["h-card"],
      "properties": {
        "photo": ["http://example.com/photo.jpg"],
        "name": ["Author"]
      }
    }
  ]
}
```